### PR TITLE
Ignore hash_change in lambda life cycle

### DIFF
--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -8,4 +8,8 @@ resource "aws_lambda_function" "this" {
 
   function_name    = "${var.name}"
   handler          = "${var.handler}"
+
+  lifecycle {
+    ignore_changes = ["source_code_hash"]
+  }
 }


### PR DESCRIPTION
For #17 

output
```
Terraform will perform the following actions:

 <= module.dynamic-secgroup.module.dynamic-secgroup.module.python.data.archive_file.service_py
      id:                  <computed>
      output_base64sha256: <computed>
      output_md5:          <computed>
      output_path:         "/Users/phuonghqh/Documents/working/terraform-aws-authenticating-secgroup/examples/getting-started/.terraform/modules/5a91bd82c16ef5fcd385e456319ed0f4/.archive.zip"
      output_sha:          <computed>
      output_size:         <computed>
      source.#:            <computed>
      source_dir:          "/Users/phuonghqh/Documents/working/terraform-aws-authenticating-secgroup/examples/getting-started/.terraform/modules/5a91bd82c16ef5fcd385e456319ed0f4/.archive"
      type:                "zip"


Plan: 0 to add, 0 to change, 0 to destroy.
```