### PR TITLE
Destroy gateway generated log

### DIFF
--- a/examples/inline/main.tf
+++ b/examples/inline/main.tf
@@ -4,8 +4,8 @@ provider "aws" {
 
 module "dynamic-secgroup" {
   source          = "../.."
-  name            = "example-terraform-aws-authenticating-secgroup"
-  description     = "example usage of terraform-aws-authenticating-secgroup"
+  name            = "example-secgroup-inline"
+  description     = "example usage of terraform-aws-authenticating-secgroup (inline)"
   time_to_expire  = 120
   log_level = "DEBUG"
   security_groups = [
@@ -23,30 +23,8 @@ module "dynamic-secgroup" {
         }
       ],
       "region_name" = "us-west-2"
-    },
-    {
-      "group_ids"   = [
-        "sg-a1a9d8d8"
-      ],
-      "rules"       = [
-        {
-          "type"      = "ingress",
-          "from_port" = 24,
-          "to_port"   = 24,
-          "protocol"  = "tcp"
-        },
-        {
-          "type"      = "ingress",
-          "from_port" = 25,
-          "to_port"   = 25,
-          "protocol"  = "tcp"
-        }
-      ],
-      "region_name" = "us-west-1"
     }
   ]
-
-
 }
 
 resource "aws_iam_policy" "this" {

--- a/examples/json/main.tf
+++ b/examples/json/main.tf
@@ -4,8 +4,8 @@ provider "aws" {
 
 module "dynamic-secgroup" {
   source          = "../../"
-  name            = "example-terraform-aws-authenticating-secgroup"
-  description     = "example usage of terraform-aws-authenticating-secgroup"
+  name            = "example-secgroup-json"
+  description     = "example usage of terraform-aws-authenticating-secgroup json files"
   time_to_expire  = 120
   log_level = "DEBUG"
   security_groups = ["${file("secgroups.json")}"]

--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,14 @@
 locals {
-  module_name                = "secgroups-${substr(uuid(), 24, 12)}"
+//  module_name                = "secgroups-${substr(uuid(), 24, 12)}"
 
-  authorize_fn_name     = "authorize-${local.module_name}"
+  authorize_fn_name     = "authorize-${var.name}"
   authorize_http_method = "POST"
 
-  revoke_fn_name        = "revoke-${local.module_name}"
+  revoke_fn_name        = "revoke-${var.name}"
   revoke_http_method    = "DELETE"
 
-  clear_fn_name         = "clear-${local.module_name}"
-  clear_event_rule_name = "clear-expired-ips-${local.module_name}"
+  clear_fn_name         = "clear-${var.name}"
+  clear_event_rule_name = "clear-expired-ips-${var.name}"
   clear_event_rate      = "rate(1 minute)"
 
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,4 @@
 locals {
-//  module_name                = "secgroups-${substr(uuid(), 24, 12)}"
-
   authorize_fn_name     = "authorize-${var.name}"
   authorize_http_method = "POST"
 

--- a/main.tf
+++ b/main.tf
@@ -38,11 +38,11 @@ resource "aws_api_gateway_account" "this" {
   cloudwatch_role_arn = "${module.sts_gateway.arn}"
 }
 
-//resource "aws_cloudwatch_log_group" "this" {
-//  depends_on = [
-//    "aws_api_gateway_rest_api.this"]
-//  name       = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.this.id}/${var.deployment_stage}"
-//}
+resource "aws_cloudwatch_log_group" "this" {
+  depends_on = [
+    "aws_api_gateway_rest_api.this"]
+  name       = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.this.id}/${var.deployment_stage}"
+}
 
 resource "aws_api_gateway_method_settings" "this" {
   depends_on  = [

--- a/modules/python/src/args.py
+++ b/modules/python/src/args.py
@@ -9,6 +9,8 @@ class Arguments:
     def __init__(self):
         self.cidr_ip = self.source_ip = None
         self.security_groups_dict = {}
+        self.origin_security_groups = None
+
         self.__region_names = [None]
         self.__event = None
         self.__security_groups = None
@@ -43,11 +45,13 @@ class Arguments:
     @property
     def security_groups(self):
         if self.__security_groups is None:
-            self.security_groups = helper.json_loads('''${security_groups}''')
+            self.origin_security_groups = helper.json_loads('''${security_groups}''')
+            self.security_groups = self.origin_security_groups
         return self.__security_groups
 
     @security_groups.setter
     def security_groups(self, groups):
+        self.logger.debug(f"origin security_groups: {groups}")
         self.__security_groups = self.normalize_groups(groups)
 
     def normalize_groups(self, groups):

--- a/modules/python/src/model.py
+++ b/modules/python/src/model.py
@@ -124,7 +124,7 @@ class SecGroup:
     def error_rules(self):
         return list(filter(lambda r: r.error, self.rules))
 
-    def revoke(self, revoke_rules=None):
+    def revoke(self):
         self.__revoke(revoke_rules=self.ingress_rules)
         args.arguments.logger.info(f"Group {self.aws_group_id} revoked, error: {self.error_rules}")
 


### PR DESCRIPTION
Able to destroy AWS Api Gateway auto generated CloudWatch Log in the Settings, i.e. `API-Gateway-Execution-Logs_ukewlwm8uk/dev`