### PR TITLE
'Api' -> 'API', 'Ec2' -> 'EC2'

### DIFF
--- a/policies.tf
+++ b/policies.tf
@@ -16,7 +16,7 @@ module "sts_lambda" {
     "logs:CreateLogStream",
     "logs:PutLogEvents"
   ]
-  description = "used by Lambda invoke Ec2 Security Group"
+  description = "used by Lambda invoke EC2 Security Group"
 }
 
 module "sts_gateway" {
@@ -33,5 +33,5 @@ module "sts_gateway" {
     "logs:GetLogEvents",
     "logs:FilterLogEvents"
   ]
-  description = "used by Api Gateway to write log (cloudwatch)"
+  description = "used by API Gateway to write log (CloudWatch)"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -10,7 +10,7 @@ variable "name" {
 
 variable "deployment_stage" {
   default     = "dev"
-  description = "Api deployment stages, ex: staging, production..."
+  description = "API deployment stages, ex: staging, production..."
 }
 
 variable "security_groups" {


### PR DESCRIPTION
@phuonghuynh 

I changed 'Api' and 'Ec2' to full caps.